### PR TITLE
Added 'Coverage' as build type for the CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,14 @@ matrix:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['gcc-5', 'g++-5']
       env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" BUILD_TYPE='Release'
+      
+    - os: linux
+      compiler: gcc
+      addons: &gcc5
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['gcc-5', 'g++-5']
+      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" BUILD_TYPE='Coverage'
 
     # Linux C++11 Clang build
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['gcc-5', 'g++-5']
-      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" BUILD_TYPE='Release'
+      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" 
+      matrix: 
+        - BUILD_TYPE='Debug'
+        - BUILD_TYPE='Release'
+        - BUILD_TYPE='Coverage'
 
     # Linux C++11 Clang build
     - os: linux
@@ -20,13 +24,19 @@ matrix:
         apt:
           sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
           packages: ['clang-3.8']
-      env: MATRIX_EVAL="CXX='clang++-3.8'" BUILD_TYPE='Release'
+      env: MATRIX_EVAL="CXX='clang++-3.8'" 
+      matrix:
+        - BUILD_TYPE='Debug'
+        - BUILD_TYPE='Release'
 
     # OSX C++11 Clang Builds
     - os: osx
       osx_image: xcode8.3
       compiler: clang
-      env: MATRIX_EVAL="CXX='clang++'" BUILD_TYPE='Release'
+      env: MATRIX_EVAL="CXX='clang++'" 
+      matrix:
+        - BUILD_TYPE='Debug'
+        - BUILD_TYPE='Release'
       
 before_install:
   - | 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['gcc-5', 'g++-5']
-      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" 
-      matrix: 
+      env: 
+        - MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'"  
         - BUILD_TYPE='Debug'
         - BUILD_TYPE='Release'
         - BUILD_TYPE='Coverage'
@@ -24,8 +24,8 @@ matrix:
         apt:
           sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
           packages: ['clang-3.8']
-      env: MATRIX_EVAL="CXX='clang++-3.8'" 
-      matrix:
+      env: 
+        - MATRIX_EVAL="CXX='clang++-3.8'" 
         - BUILD_TYPE='Debug'
         - BUILD_TYPE='Release'
 
@@ -33,8 +33,8 @@ matrix:
     - os: osx
       osx_image: xcode8.3
       compiler: clang
-      env: MATRIX_EVAL="CXX='clang++'" 
-      matrix:
+      env:
+        - MATRIX_EVAL="CXX='clang++'" 
         - BUILD_TYPE='Debug'
         - BUILD_TYPE='Release'
       

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,14 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['gcc-5', 'g++-5']
+      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" BUILD_TYPE='Debug'
+      
+    - os: linux
+      compiler: gcc
+      addons: &gcc5
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['gcc-5', 'g++-5']
       env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" BUILD_TYPE='Release'
       
     - os: linux
@@ -28,9 +36,22 @@ matrix:
         apt:
           sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
           packages: ['clang-3.8']
+      env: MATRIX_EVAL="CXX='clang++-3.8'" BUILD_TYPE='Debug'
+      
+    - os: linux
+      compiler: clang
+      addons: &clang38
+        apt:
+          sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
+          packages: ['clang-3.8']
       env: MATRIX_EVAL="CXX='clang++-3.8'" BUILD_TYPE='Release'
 
     # OSX C++11 Clang Builds
+    - os: osx
+      osx_image: xcode8.3
+      compiler: clang
+      env: MATRIX_EVAL="CXX='clang++'" BUILD_TYPE='Debug'
+      
     - os: osx
       osx_image: xcode8.3
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['gcc-5', 'g++-5']
-      env: 
-        - MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'"  
-        - BUILD_TYPE='Debug'
-        - BUILD_TYPE='Release'
-        - BUILD_TYPE='Coverage'
+      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'"
+      matrix:
+        - env: BUILD_TYPE='Debug'
+        - env: BUILD_TYPE='Release'
+        - env: BUILD_TYPE='Coverage'
 
     # Linux C++11 Clang build
     - os: linux
@@ -24,19 +24,19 @@ matrix:
         apt:
           sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
           packages: ['clang-3.8']
-      env: 
-        - MATRIX_EVAL="CXX='clang++-3.8'" 
-        - BUILD_TYPE='Debug'
-        - BUILD_TYPE='Release'
-
+      env: MATRIX_EVAL="CXX='clang++-3.8'" 
+      matrix:
+        - env: BUILD_TYPE='Debug'
+        - env: BUILD_TYPE='Release'
+        
     # OSX C++11 Clang Builds
     - os: osx
       osx_image: xcode8.3
       compiler: clang
-      env:
-        - MATRIX_EVAL="CXX='clang++'" 
-        - BUILD_TYPE='Debug'
-        - BUILD_TYPE='Release'
+      env:MATRIX_EVAL="CXX='clang++'" 
+      matrix:
+        - env: BUILD_TYPE='Debug'
+        - env: BUILD_TYPE='Release'
       
 before_install:
   - | 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,24 @@
 language: cpp
 sudo: true
 
+os: linux
+compiler:
+- gcc
+- clang
+addons:
+- &gcc5
+- &clang38
+apt:
+- sources: ['ubuntu-toolchain-r-test'] packages: ['gcc-5', 'g++-5']
+- sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test'] packages: ['clang-3.8']
+env:
+- MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'"
+- MATRIX_EVAL="CXX='clang++-3.8'"
+- CMAKE_BUILD_TYPE="Debug"
+- CMAKE_BUILD_TYPE="Release"
+
 matrix:
   include:
-
     # Linux C++11 GCC build
     - os: linux
       compiler: gcc
@@ -11,32 +26,13 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['gcc-5', 'g++-5']
-      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'"
-      matrix:
-        - env: BUILD_TYPE='Debug'
-        - env: BUILD_TYPE='Release'
-        - env: BUILD_TYPE='Coverage'
-
-    # Linux C++11 Clang build
-    - os: linux
-      compiler: clang
-      addons: &clang38
-        apt:
-          sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
-          packages: ['clang-3.8']
-      env: MATRIX_EVAL="CXX='clang++-3.8'" 
-      matrix:
-        - env: BUILD_TYPE='Debug'
-        - env: BUILD_TYPE='Release'
+      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" CMAKE_BUILD_TYPE="Coverage"
         
     # OSX C++11 Clang Builds
     - os: osx
       osx_image: xcode8.3
       compiler: clang
       env:MATRIX_EVAL="CXX='clang++'" 
-      matrix:
-        - env: BUILD_TYPE='Debug'
-        - env: BUILD_TYPE='Release'
       
 before_install:
   - | 

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ install:
       which cmake || brew install cmake
     fi
   - |
-    if [[ "${CXX}" == "g++-5" ]]; then
+    if [[ "${BUILD_TYPE}" == "Coverage" ]]; then
       # Install LCOV 1.11
       cd ${DEPS_DIR}
       wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz
@@ -100,7 +100,7 @@ install:
 before_script:
   - cd ${TRAVIS_BUILD_DIR}
   - |
-    if [[ "${CXX}" == "g++-5" ]]; then
+    if [[ "${BUILD_TYPE}" == "Coverage" ]]; then
       lcov --directory . --zerocounters
     fi
   - mkdir -p build && cd build
@@ -112,7 +112,7 @@ script:
   
 after_success:
   - |
-      if [ "${CXX}" == "g++-5" ]; then
+      if [ "${BUILD_TYPE}" == "Coverage" ]; then
         # Generate code coverage information & send to Coveralls
         lcov --gcov-tool gcov-5 --directory ${TRAVIS_BUILD_DIR}/build --capture --output-file coverage.info
         lcov --remove coverage.info 'tests/*' 'msgs/include/simple_msgs/generated/*' '/usr/*' --output-file coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,7 @@ sudo: true
 matrix:
   include:
 
-    # Linux C++11 GCC builds
-    - os: linux
-      compiler: gcc
-      addons: &gcc5
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['gcc-5', 'g++-5']
-      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" BUILD_TYPE='Debug'
-   
+    # Linux C++11 GCC build
     - os: linux
       compiler: gcc
       addons: &gcc5
@@ -20,24 +12,8 @@ matrix:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['gcc-5', 'g++-5']
       env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" BUILD_TYPE='Release'
-      
-     - os: linux
-      compiler: gcc
-      addons: &gcc5
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['gcc-5', 'g++-5']
-      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" BUILD_TYPE='Coverage'
 
     # Linux C++11 Clang build
-    - os: linux
-      compiler: clang
-      addons: &clang38
-        apt:
-          sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
-          packages: ['clang-3.8']
-      env: MATRIX_EVAL="CXX='clang++-3.8'" BUILD_TYPE='Debug'
-      
     - os: linux
       compiler: clang
       addons: &clang38
@@ -50,20 +26,15 @@ matrix:
     - os: osx
       osx_image: xcode8.3
       compiler: clang
-      env: MATRIX_EVAL="CXX='clang++'" BUILD_TYPE='Debug'    
-    
-    - os: osx
-      osx_image: xcode8.3
-      compiler: clang
       env: MATRIX_EVAL="CXX='clang++'" BUILD_TYPE='Release'
-
+      
 before_install:
-  - |
+  - | 
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
       sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60" # Hopefully preventing Travis to fail when installing from apt
     fi
   - eval "${MATRIX_EVAL}"
-
+  
 install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
   - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
@@ -109,7 +80,7 @@ before_script:
 script:
   - make -j8
   - ctest -R simple_tests -C Release --output-on-failure
-
+  
 after_success:
   - |
       if [ "${CXX}" == "g++-5" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,69 @@
 language: cpp
 sudo: true
 
-os: linux
-compiler:
-- gcc
-- clang
-addons:
-- &gcc5
-- &clang38
-apt:
-- sources: ['ubuntu-toolchain-r-test'] packages: ['gcc-5', 'g++-5']
-- sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test'] packages: ['clang-3.8']
-env:
-- MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'"
-- MATRIX_EVAL="CXX='clang++-3.8'"
-- CMAKE_BUILD_TYPE="Debug"
-- CMAKE_BUILD_TYPE="Release"
-
 matrix:
   include:
-    # Linux C++11 GCC build
+
+    # Linux C++11 GCC builds
     - os: linux
       compiler: gcc
       addons: &gcc5
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['gcc-5', 'g++-5']
-      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" CMAKE_BUILD_TYPE="Coverage"
-        
+      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" BUILD_TYPE='Debug'
+   
+    - os: linux
+      compiler: gcc
+      addons: &gcc5
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['gcc-5', 'g++-5']
+      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" BUILD_TYPE='Release'
+      
+     - os: linux
+      compiler: gcc
+      addons: &gcc5
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['gcc-5', 'g++-5']
+      env: MATRIX_EVAL="CC='gcc-5' && CXX='g++-5'" BUILD_TYPE='Coverage'
+
+    # Linux C++11 Clang build
+    - os: linux
+      compiler: clang
+      addons: &clang38
+        apt:
+          sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
+          packages: ['clang-3.8']
+      env: MATRIX_EVAL="CXX='clang++-3.8'" BUILD_TYPE='Debug'
+      
+    - os: linux
+      compiler: clang
+      addons: &clang38
+        apt:
+          sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
+          packages: ['clang-3.8']
+      env: MATRIX_EVAL="CXX='clang++-3.8'" BUILD_TYPE='Release'
+
     # OSX C++11 Clang Builds
     - os: osx
       osx_image: xcode8.3
       compiler: clang
-      env:MATRIX_EVAL="CXX='clang++'" 
-      
+      env: MATRIX_EVAL="CXX='clang++'" BUILD_TYPE='Debug'    
+    
+    - os: osx
+      osx_image: xcode8.3
+      compiler: clang
+      env: MATRIX_EVAL="CXX='clang++'" BUILD_TYPE='Release'
+
 before_install:
-  - | 
+  - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
       sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60" # Hopefully preventing Travis to fail when installing from apt
     fi
   - eval "${MATRIX_EVAL}"
-  
+
 install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
   - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
@@ -86,7 +109,7 @@ before_script:
 script:
   - make -j8
   - ctest -R simple_tests -C Release --output-on-failure
-  
+
 after_success:
   - |
       if [ "${CXX}" == "g++-5" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 # Tests
 if (${SIMPLE_BUILD_TESTS})
   include(CTest)
-  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU") # Coverage flags for GCC
+  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_BUILD_TYPE MATCHES "Coverage") # Coverage flags for GCC
     add_compile_options(-g -O0 -fprofile-arcs -ftest-coverage)
     set(coverage_lib gcov)
   endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,12 +29,12 @@ install:
   - git clone https://github.com/google/flatbuffers.git # Checkout master (for the moment)
   - cd flatbuffers && mkdir flatbuffer_build && cd flatbuffer_build
   - cmake -G "%CMAKE_GENERATOR% Win64" -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
-  - cmake --build . --target install --config Release
+  - cmake --build . --target install --config %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%/deps
   - git clone https://github.com/zeromq/libzmq.git # Checkout master (for the moment)
   - cd libzmq && mkdir libzmq_build && cd libzmq_build
   - cmake -G "%CMAKE_GENERATOR% Win64" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DZMQ_BUILD_TESTS=OFF ..
-  - cmake --build . --target install --config Release
+  - cmake --build . --target install --config %CONFIGURATION%
 
 before_build:
   - cd %APPVEYOR_BUILD_FOLDER%
@@ -43,7 +43,7 @@ before_build:
   - cmake -G "%CMAKE_GENERATOR% Win64" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DSIMPLE_BUILD_TESTS=ON -DSIMPLE_BUILD_EXAMPLES=ON ..
 
 build_script:
-  - cmake --build . --config Release -- /verbosity:minimal
+  - cmake --build . --config %CONFIGURATION% -- /verbosity:minimal
 
 test_script:
   - ctest -R simple_tests -C %CONFIGURATION% --output-on-failure

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ os:
 skip_tags: true
 
 configuration:
-  - Debug
   - Release
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ os:
 skip_tags: true
 
 configuration:
-  - Debug
   - Release
 
 environment:
@@ -28,8 +27,8 @@ install:
   - mkdir deps && cd deps
   - git clone https://github.com/google/flatbuffers.git # Checkout master
   - cd flatbuffers && mkdir flatbuffer_build && cd flatbuffer_build
-  - cmake -G "%CMAKE_GENERATOR% Win64" -DCMAKE_BUILD_TYPE=Release .. # Flatbuffers doesn't install flatc other than in Release.
-  - cmake --build . --target install --config Release
+  - cmake -G "%CMAKE_GENERATOR% Win64" -DCMAKE_BUILD_TYPE=%CONFIGURATION% .. # Flatbuffers doesn't install flatc other than in Release.
+  - cmake --build . --target install --config %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%/deps
   - git clone https://github.com/zeromq/libzmq.git # Checkout master
   - cd libzmq && mkdir libzmq_build && cd libzmq_build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,15 +26,15 @@ matrix:
 
 install:
   - mkdir deps && cd deps
-  - git clone https://github.com/google/flatbuffers.git # Checkout master (for the moment)
+  - git clone https://github.com/google/flatbuffers.git # Checkout master
   - cd flatbuffers && mkdir flatbuffer_build && cd flatbuffer_build
-  - cmake -G "%CMAKE_GENERATOR% Win64" -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
-  - cmake --build . --target install --config %CONFIGURATION%
-  - cd %APPVEYOR_BUILD_FOLDER%/deps
-  - git clone https://github.com/zeromq/libzmq.git # Checkout master (for the moment)
-  - cd libzmq && mkdir libzmq_build && cd libzmq_build
-  - cmake -G "%CMAKE_GENERATOR% Win64" -DCMAKE_BUILD_TYPE=%CONFIGURATION -DENABLE_CURVE=OFF -DZMQ_BUILD_TESTS=OFF ..
+  - cmake -G "%CMAKE_GENERATOR% Win64" -DCMAKE_BUILD_TYPE=Release .. # Flatbuffers doesn't install flatc other than in Release.
   - cmake --build . --target install --config Release
+  - cd %APPVEYOR_BUILD_FOLDER%/deps
+  - git clone https://github.com/zeromq/libzmq.git # Checkout master
+  - cd libzmq && mkdir libzmq_build && cd libzmq_build
+  - cmake -G "%CMAKE_GENERATOR% Win64" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DENABLE_CURVE=OFF -DZMQ_BUILD_TESTS=OFF ..
+  - cmake --build . --target install --config %CONFIGURATION%
 
 before_build:
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ os:
 skip_tags: true
 
 configuration:
+  - Debug
   - Release
 
 environment:

--- a/examples/src/example_image_subscriber.cpp
+++ b/examples/src/example_image_subscriber.cpp
@@ -36,9 +36,7 @@ void example_callback(const simple_msgs::Image<uint8_t>& i) {
   // Build an OpenCV Mat from those.
   cv::Mat received_img{dimensions[1], dimensions[0], CV_8UC(i.getNumChannels()), img};
   received_img.copyTo(buffer);
-
   cv::imshow(window_name, buffer);
-
   std::cout << "Message # " << i.getHeader().getSequenceNumber() << " received !" << std::endl;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,5 +103,5 @@ TARGETS
   test_pub_sub 
   test_req_rep
 DESTINATION 
-	bin
+  bin
 )


### PR DESCRIPTION
Now the coverage options (which disable compiler optimization) are only used when the 'Coverage' configuration is selected.

Also building SIMPLE in Debug mode on Linux/OSX, on Windows there are some problems with Flatbuffers.

Fixes #21 