### PR TITLE
Fixing windows shared library issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>)
 
 target_link_libraries(${PROJECT_NAME}
-  libzmq ${CMAKE_THREAD_LIBS_INIT} simple_msgs ${coverage_lib})
+  libzmq-static ${CMAKE_THREAD_LIBS_INIT} simple_msgs ${coverage_lib})
 
 # Generate the export header for the shared library.
 include(GenerateExportHeader)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ add_custom_target(${PROJECT_NAME}-ide SOURCES ${SIMPLE_HEADERS})
 add_library(${PROJECT_NAME} SHARED src/context_manager.cpp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/msgs/include>
   $<BUILD_INTERFACE:${ZeroMQ_INCLUDE_DIR}>
@@ -96,7 +96,7 @@ add_library(${PROJECT_NAME}-static src/context_manager.cpp)
 target_compile_definitions(${PROJECT_NAME}-static PUBLIC SIMPLE_STATIC_DEFINE)
 
 target_include_directories(${PROJECT_NAME}-static PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/msgs/include>
   $<BUILD_INTERFACE:${ZeroMQ_INCLUDE_DIR}>
@@ -117,7 +117,7 @@ install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}-static
 
 # Install SIMPLE includes
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${CMAKE_CURRENT_SOURCE_DIR}/simpleConfigVersion.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ endif(WIN32)
 
 set(CMAKE_DEBUG_POSTFIX "-d")
 
+# output all binaries and libs into a common folder across all libraries
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 if(MSVC)
   add_compile_options(/W4 /w44640 /WX)
   if (MSVC_VERSION GREATER 1900)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.3)
 project(simple)
 
-# Set the project version
+# Set the project version.
 set(PROJECT_VER_PATCH 0)
 set(PROJECT_VER_MINOR 0)
 set(PROJECT_VER_MAJOR 1)
@@ -12,18 +12,18 @@ include(GNUInstallDirs)
 
 ###### GLOBAL PARAMETERS AND SETTINGS
 
-# Here all the compiler options for all projects created are set
+# Here all the compiler options for all projects created are set.
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Allows all symbols generated from the dynamic library to be exported
+# Allows all symbols generated from the dynamic library to be exported.
 if (WIN32)
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 endif(WIN32)
 
 set(CMAKE_DEBUG_POSTFIX "-d")
 
-# output all binaries and libs into a common folder across all libraries
+# Output all binaries and libs into a common folder across all libraries.
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -42,12 +42,12 @@ endif()
 option(SIMPLE_BUILD_EXAMPLES "Build SIMPLE Examples" FALSE)
 option(SIMPLE_BUILD_TESTS "Build SIMPLE Tests" FALSE)
 
-# Examples
+# Examples.
 if (${SIMPLE_BUILD_EXAMPLES})
   add_subdirectory(examples)
 endif()
 
-# Tests
+# Tests.
 if (${SIMPLE_BUILD_TESTS})
   include(CTest)
   if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_BUILD_TYPE MATCHES "Coverage") # Coverage flags for GCC
@@ -72,7 +72,7 @@ find_package(ZeroMQ REQUIRED)
 file(GLOB SIMPLE_HEADERS "include/simple/*.hpp")
 add_custom_target(${PROJECT_NAME}-ide SOURCES ${SIMPLE_HEADERS})
 
-# SHARED library
+# SHARED library.
 add_library(${PROJECT_NAME} SHARED src/context_manager.cpp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
@@ -85,14 +85,14 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_link_libraries(${PROJECT_NAME}
   libzmq ${CMAKE_THREAD_LIBS_INIT} simple_msgs ${coverage_lib})
 
-# generate the export header for the shared library
+# Generate the export header for the shared library.
 include(GenerateExportHeader)
 generate_export_header(${PROJECT_NAME})
 
-# STATIC library
+# STATIC library.
 add_library(${PROJECT_NAME}-static src/context_manager.cpp)
 
-# required for the generated export header
+# Required for the generated export header.
 target_compile_definitions(${PROJECT_NAME}-static PUBLIC SIMPLE_STATIC_DEFINE)
 
 target_include_directories(${PROJECT_NAME}-static PUBLIC
@@ -107,7 +107,7 @@ target_link_libraries(${PROJECT_NAME}-static
 
 ###### INSTALLATION
 
-# Install SIMPLE in the desired folder
+# Install SIMPLE in the desired folder.
 install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}-static
   EXPORT "simpleTargets"
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -115,7 +115,7 @@ install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}-static
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-# Install SIMPLE includes
+# Install SIMPLE includes.
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,7 @@ generate_export_header(${PROJECT_NAME})
 add_library(${PROJECT_NAME}-static src/context_manager.cpp)
 
 # required for the generated export header
-set_target_properties(${PROJECT_NAME}-static PROPERTIES
-  COMPILE_FLAGS -DSIMPLE_STATIC_DEFINE)
+target_compile_definitions(${PROJECT_NAME}-static PUBLIC SIMPLE_STATIC_DEFINE)
 
 target_include_directories(${PROJECT_NAME}-static PUBLIC
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,9 +67,11 @@ find_package(ZeroMQ REQUIRED)
 file(GLOB SIMPLE_HEADERS "include/simple/*.hpp")
 add_custom_target(${PROJECT_NAME}-ide SOURCES ${SIMPLE_HEADERS})
 
-add_library(${PROJECT_NAME} src/context_manager.cpp)
+# SHARED library
+add_library(${PROJECT_NAME} SHARED src/context_manager.cpp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/msgs/include>
   $<BUILD_INTERFACE:${ZeroMQ_INCLUDE_DIR}>
@@ -78,9 +80,19 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_link_libraries(${PROJECT_NAME}
   libzmq ${CMAKE_THREAD_LIBS_INIT} simple_msgs ${coverage_lib})
 
+# generate the export header for the shared library
+include(GenerateExportHeader)
+generate_export_header(${PROJECT_NAME})
+
+# STATIC library
 add_library(${PROJECT_NAME}-static src/context_manager.cpp)
 
+# required for the generated export header
+set_target_properties(${PROJECT_NAME}-static PROPERTIES
+  COMPILE_FLAGS -DSIMPLE_STATIC_DEFINE)
+
 target_include_directories(${PROJECT_NAME}-static PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/msgs/include>
   $<BUILD_INTERFACE:${ZeroMQ_INCLUDE_DIR}>
@@ -101,6 +113,7 @@ install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}-static
 
 # Install SIMPLE includes
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${CMAKE_CURRENT_SOURCE_DIR}/simpleConfigVersion.cmake"

--- a/include/simple/context_manager.hpp
+++ b/include/simple/context_manager.hpp
@@ -49,9 +49,16 @@ public:
     return context_->getContext();
   }
 
+  /**
+   * @brief Destroys the current instance of the ZMQ context
+   *
+   * It is sometimes required to control the lifetime of the zmq context object explicitly, most notably
+   * when using simple as (or from a) dynamic library. In such a case, the context needs to be destroyed
+   * _before_ the DLL gets unloaded.
+   */
   static void destroy() {
-	  // TODO lock?
-	  context_ = nullptr;
+	std::lock_guard<std::mutex> lock(context_creation_mutex_);
+    context_ = nullptr;
   }
 
 private:
@@ -86,8 +93,8 @@ private:
     void* internal_context_{nullptr};  //< Atomic static ZMQ Context.
   };
   static SIMPLE_EXPORT std::mutex context_creation_mutex_;
-  static SIMPLE_EXPORT std::shared_ptr<ZMQContext> context_;  //< This allows to automatically dispose (and therefore, terminate) the
-                                                // ZMQ context handled by the ZMQContext class.
+  static SIMPLE_EXPORT std::shared_ptr<ZMQContext> context_;	//< This allows to automatically dispose (and therefore, terminate) the
+																// ZMQ context handled by the ZMQContext class.
 };
 }  // Namespace simple.
 

--- a/include/simple/context_manager.hpp
+++ b/include/simple/context_manager.hpp
@@ -43,7 +43,7 @@ public:
    * That instantiation performs thread-safe operations to create/dispose the underlying ZMQ context object.
    */
   static void* instance() {
-    std::lock_guard<std::mutex> lock(context_creation_mutex_);
+    std::lock_guard<std::mutex> lock{context_creation_mutex_};
     // Make a new context and atomically swap it with the member context.
     if (context_ == nullptr) { context_ = std::make_shared<ZMQContext>(); }
     return context_->getContext();
@@ -57,7 +57,7 @@ public:
    * _before_ the DLL gets unloaded.
    */
   static void destroy() {
-	std::lock_guard<std::mutex> lock(context_creation_mutex_);
+    std::lock_guard<std::mutex> lock{context_creation_mutex_};
     context_ = nullptr;
   }
 
@@ -79,7 +79,7 @@ private:
     ZMQContext(ZMQContext&&) = delete;
     ZMQContext& operator=(ZMQContext&&) = delete;
 
-    // Terminate the static ZMQ context instance.
+    // Terminate the ZMQ context instance.
     ~ZMQContext() {
       if (internal_context_ != nullptr) { zmq_ctx_term(internal_context_); }
     }
@@ -90,7 +90,7 @@ private:
     void* getContext() { return internal_context_; }
 
   private:
-    void* internal_context_{nullptr};  //< Atomic static ZMQ Context.
+    void* internal_context_{nullptr};  //< ZMQ Context.
   };
   static SIMPLE_EXPORT std::mutex context_creation_mutex_;
   static SIMPLE_EXPORT std::shared_ptr<ZMQContext> context_;	//< This allows to automatically dispose (and therefore, terminate) the

--- a/include/simple/context_manager.hpp
+++ b/include/simple/context_manager.hpp
@@ -20,6 +20,8 @@
 #ifndef SIMPLE_CONTEXT_MANAGER_HPP
 #define SIMPLE_CONTEXT_MANAGER_HPP
 
+#include "simple_export.h"
+
 #include <zmq.h>
 #include <memory>
 #include <mutex>
@@ -45,6 +47,11 @@ public:
     // Make a new context and atomically swap it with the member context.
     if (context_ == nullptr) { context_ = std::make_shared<ZMQContext>(); }
     return context_->getContext();
+  }
+
+  static void destroy() {
+	  // TODO lock?
+	  context_ = nullptr;
   }
 
 private:
@@ -78,8 +85,8 @@ private:
   private:
     void* internal_context_{nullptr};  //< Atomic static ZMQ Context.
   };
-  static std::mutex context_creation_mutex_;
-  static std::shared_ptr<ZMQContext> context_;  //< This allows to automatically dispose (and therefore, terminate) the
+  static SIMPLE_EXPORT std::mutex context_creation_mutex_;
+  static SIMPLE_EXPORT std::shared_ptr<ZMQContext> context_;  //< This allows to automatically dispose (and therefore, terminate) the
                                                 // ZMQ context handled by the ZMQContext class.
 };
 }  // Namespace simple.

--- a/include/simple/context_manager.hpp
+++ b/include/simple/context_manager.hpp
@@ -54,7 +54,10 @@ public:
    *
    * It is sometimes required to control the lifetime of the zmq context object explicitly, most notably
    * when using simple as (or from a) dynamic library. In such a case, the context needs to be destroyed
-   * _before_ the DLL gets unloaded.
+   * _before_ the DLL gets unloaded, but _after_ any other SIMPLE objects are destroyed.
+   * @Note Under normal circumstances, using this function is not necessary as the context normally will
+   *       be destroyed at static object destruction. Use this only when necessary and be aware that 
+   *       early destruction can result in application crashes or hangs.
    */
   static void destroy() {
     std::lock_guard<std::mutex> lock{context_creation_mutex_};

--- a/include/simple/server.hpp
+++ b/include/simple/server.hpp
@@ -82,7 +82,7 @@ private:
   void stop() {
     if (isValid()) {
       alive_->store(false);
-      if (server_thread_.joinable()) { server_thread_.detach(); }
+      if (server_thread_.joinable()) { server_thread_.join(); }
     }
   }
 

--- a/include/simple/subscriber.hpp
+++ b/include/simple/subscriber.hpp
@@ -81,7 +81,7 @@ public:
   inline void stop() {
     if (isValid()) {
       alive_->store(false);
-      if (subscriber_thread_.joinable()) { subscriber_thread_.detach(); }
+      if (subscriber_thread_.joinable()) { subscriber_thread_.join(); }
     }
   }
 

--- a/msgs/CMakeLists.txt
+++ b/msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.3)
 project(simple_msgs)
 
-# Find FlatBuffers
+# Find FlatBuffers and Flatc.
 find_package(Flatbuffers REQUIRED)
 
 find_program(FLATBUFFERS_FLATC_EXECUTABLE flatc
@@ -16,6 +16,7 @@ if(NOT FLATBUFFERS_FLATC_EXECUTABLE)
 	message(FATAL_ERROR "Flatbuffers' flatc could not be found. Please set FLATBUFFERS_FLATC_EXECUTABLE manually!")
 endif()
 
+# CMake function that generates Flatbuffers headers from fbs files in the given directory.
 function(flatbuffers_generate_c_headers NAME FBS_DIR OUTPUT_DIR)
   set(FLATC_OUTPUTS)
   file(GLOB FBS_FILES ${FBS_DIR}/*.fbs)
@@ -28,6 +29,8 @@ function(flatbuffers_generate_c_headers NAME FBS_DIR OUTPUT_DIR)
   endforeach()
   set(${NAME}_OUTPUTS ${FLATC_OUTPUTS} PARENT_SCOPE)
 endfunction()
+
+###### SOURCE FILES
 
 file(GLOB_RECURSE SIMPLE_MSGS_HEADERS "*.h" "*.hpp")
 
@@ -47,8 +50,10 @@ set(SIMPLE_MSGS_SRCS
   src/rotation_matrix_stamped.cpp
   )
 
-# Generate the Flatbuffers headers
+# Generate the Flatbuffers headers.
 flatbuffers_generate_c_headers(simple_msgs ${PROJECT_SOURCE_DIR}/fbs ${PROJECT_SOURCE_DIR}/include/simple_msgs/generated)
+
+###### TARGETS
 
 add_library(${PROJECT_NAME} STATIC ${SIMPLE_MSGS_SRCS})
 target_include_directories(${PROJECT_NAME} PUBLIC
@@ -61,7 +66,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC flatbuffers::flatbuffers)
 
 ###### INSTALLATION
 
-# Install the simple_msgs library in the desired folder
+# Install the simple_msgs library in the desired folder.
 install(TARGETS ${PROJECT_NAME} EXPORT "simpleTargets"
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/msgs/include/simple_msgs/double.hpp
+++ b/msgs/include/simple_msgs/double.hpp
@@ -26,17 +26,17 @@ namespace simple_msgs {
 using Double = NumericType<double>;
 
 template <>
-NumericType<double>::NumericType(const void* data) : data_{GetDoubleFbs(data)->data()} {}
+inline NumericType<double>::NumericType(const void* data) : data_{GetDoubleFbs(data)->data()} {}
 
 template <>
-NumericType<double>& NumericType<double>::operator=(std::shared_ptr<void*> data) {
+inline NumericType<double>& NumericType<double>::operator=(std::shared_ptr<void*> data) {
   std::lock_guard<std::mutex> lock{mutex_};
   data_ = GetDoubleFbs(*data)->data();
   return *this;
 }
 
 template <>
-std::shared_ptr<flatbuffers::DetachedBuffer> NumericType<double>::getBufferData() const {
+inline std::shared_ptr<flatbuffers::DetachedBuffer> NumericType<double>::getBufferData() const {
   std::lock_guard<std::mutex> lock{mutex_};
   flatbuffers::FlatBufferBuilder builder{1024};
   DoubleFbsBuilder tmp_builder{builder};

--- a/msgs/include/simple_msgs/float.hpp
+++ b/msgs/include/simple_msgs/float.hpp
@@ -26,17 +26,17 @@ namespace simple_msgs {
 using Float = NumericType<float>;
 
 template <>
-NumericType<float>::NumericType(const void* data) : data_{GetFloatFbs(data)->data()} {}
+inline NumericType<float>::NumericType(const void* data) : data_{GetFloatFbs(data)->data()} {}
 
 template <>
-NumericType<float>& NumericType<float>::operator=(std::shared_ptr<void*> data) {
+inline NumericType<float>& NumericType<float>::operator=(std::shared_ptr<void*> data) {
   std::lock_guard<std::mutex> lock{mutex_};
   data_ = GetFloatFbs(*data)->data();
   return *this;
 }
 
 template <>
-std::shared_ptr<flatbuffers::DetachedBuffer> NumericType<float>::getBufferData() const {
+inline std::shared_ptr<flatbuffers::DetachedBuffer> NumericType<float>::getBufferData() const {
   std::lock_guard<std::mutex> lock{mutex_};
   flatbuffers::FlatBufferBuilder builder{1024};
   FloatFbsBuilder tmp_builder{builder};

--- a/msgs/include/simple_msgs/int.hpp
+++ b/msgs/include/simple_msgs/int.hpp
@@ -26,17 +26,17 @@ namespace simple_msgs {
 using Int = NumericType<int>;
 
 template <>
-NumericType<int>::NumericType(const void* data) : data_{GetIntFbs(data)->data()} {}
+inline NumericType<int>::NumericType(const void* data) : data_{GetIntFbs(data)->data()} {}
 
 template <>
-NumericType<int>& NumericType<int>::operator=(std::shared_ptr<void*> data) {
+inline NumericType<int>& NumericType<int>::operator=(std::shared_ptr<void*> data) {
   std::lock_guard<std::mutex> lock{mutex_};
   data_ = GetIntFbs(*data)->data();
   return *this;
 }
 
 template <>
-std::shared_ptr<flatbuffers::DetachedBuffer> NumericType<int>::getBufferData() const {
+inline std::shared_ptr<flatbuffers::DetachedBuffer> NumericType<int>::getBufferData() const {
   std::lock_guard<std::mutex> lock{mutex_};
   flatbuffers::FlatBufferBuilder builder{1024};
   IntFbsBuilder tmp_builder{builder};

--- a/src/context_manager.cpp
+++ b/src/context_manager.cpp
@@ -1,4 +1,4 @@
 #include <simple/context_manager.hpp>
 
-std::mutex simple::ContextManager::context_creation_mutex_;
+std::mutex simple::ContextManager::context_creation_mutex_{};
 std::shared_ptr<simple::ContextManager::ZMQContext> simple::ContextManager::context_{nullptr};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 include_directories(include)
 
-#TESTS FOR WRAPPERS
+# TESTS FOR WRAPPERS
 add_executable(test_bool test_bool.cpp)
 target_link_libraries(test_bool simple-static ${coverage_lib})
 add_test(NAME simple_tests.bool COMMAND $<TARGET_FILE:test_bool>)
@@ -98,6 +98,11 @@ add_executable(test_req_rep test_single_req_rep.cpp)
 target_link_libraries(test_req_rep simple-static ${coverage_lib})
 add_test(NAME simple_tests.req_rep COMMAND $<TARGET_FILE:test_req_rep>)
 
+# CONTEXT_MANAGER TESTS
+add_executable(test_context_manager test_context_manager.cpp)
+target_link_libraries(test_context_manager simple ${coverage_lib})
+add_test(NAME simple_tests.context_manager COMMAND $<TARGET_FILE:test_context_manager>)
+
 install(
 TARGETS
   test_bool
@@ -117,6 +122,7 @@ TARGETS
   test_rotation_matrix_stamped
   test_pub_sub 
   test_req_rep
+  test_context_manager
 DESTINATION 
   bin
 )

--- a/tests/test_context_manager.cpp
+++ b/tests/test_context_manager.cpp
@@ -1,0 +1,37 @@
+/**
+ * S.I.M.P.L.E. - Smart Intuitive Messaging Platform with Less Effort
+ * Copyright (C) 2018 Salvatore Virga - salvo.virga@tum.de, Fernanda Levy
+ * Langsch - fernanda.langsch@tum.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define CATCH_CONFIG_MAIN
+
+#include "catch.hpp"
+
+#include "simple/publisher.hpp"
+#include "simple_msgs/bool.h"
+
+// Test: Context Manager lifetime using dynamic Linkage.
+
+SCENARIO("SIMPLE ContextManager lifetime using dynamic linkage") {
+  GIVEN("A SIMPLE object.") {
+    simple::Publisher<simple_msgs::Bool> publisher{"tcp://*:6666"};
+    WHEN("The application exits.") {
+      THEN("The ContextManager has to be destroyed before the dynamic library is unloaded.") {}
+    }
+  }
+  simple::ContextManager::destroy();
+}

--- a/tests/test_context_manager.cpp
+++ b/tests/test_context_manager.cpp
@@ -29,8 +29,8 @@
 SCENARIO("SIMPLE ContextManager lifetime using dynamic linkage") {
   GIVEN("A SIMPLE object.") {
     simple::Publisher<simple_msgs::Bool> publisher{"tcp://*:6666"};
-    WHEN("The application exits.") {
-      THEN("The ContextManager has to be destroyed before the dynamic library is unloaded.") {}
+    WHEN("The application exits and the ContextManager is destroyed before the dynamic library is unloaded.") {
+      THEN("The applications exits cleanly.") {}
     }
   }
   simple::ContextManager::destroy();


### PR DESCRIPTION
This fixes unresolved linker errors for the two static symbols now imported from the shared lib. simple::simple is now also forced shared lib. WINDOWS_EXPORT_ALL_SYMBOLS unfortunately only works for functions but not for static data members. An alternative approach would be to hide the static member a local static variable of the instance() function.

Also adds a method to context_manager to destroy it, fixing #26 

This could need a test case but I'm not sure how it would look like. @SalvoVirga can you suggest something?